### PR TITLE
use plugin prefix as key, to control from config file

### DIFF
--- a/lib/logstash/outputs/s3/temporary_file_factory.rb
+++ b/lib/logstash/outputs/s3/temporary_file_factory.rb
@@ -71,9 +71,8 @@ module LogStash
 
         def new_file
           uuid = SecureRandom.uuid
-          name = generate_name
           path = ::File.join(temporary_directory, uuid)
-          key = ::File.join(prefix, name)
+          key = prefix
 
           FileUtils.mkdir_p(::File.join(path, prefix))
 


### PR DESCRIPTION
I want to use prefix as key in order to control the key name from the plugin config.
this allows us two improvements:
1) rotation by seconds for tests (like the file output plugin)
2) use of the same timestamp to create dir and file name, which could have caused issues in crossover times (file created on the 3rd going into the 4th dir).


prefix => "logs/live/%{[@metadata][year]}/%{[@metadata][month]}/%{[@metadata][day]}/%{[@metadata][system_time]}.txt.gz"